### PR TITLE
WIP: refactor: Output AI SDK v3 format directly, fix usage conversion error

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "opencode-codex-provider",
@@ -8,44 +9,50 @@
         "typescript": "^5.8.2",
       },
       "peerDependencies": {
-        "@ai-sdk/provider": ">=2.0.0",
+        "@ai-sdk/provider": "3.0.8",
         "opencode-ai": ">=0.14.4",
       },
     },
   },
   "packages": {
-    "@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
-    "@types/bun": ["@types/bun@1.2.23", "", { "dependencies": { "bun-types": "1.2.23" } }, "sha512-le8ueOY5b6VKYf19xT3McVbXqLqmxzPXHsQT/q9JHgikJ2X22wyTW3g3ohz2ZMnp7dod6aduIiq8A14Xyimm0A=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "@types/node": ["@types/node@24.7.0", "", { "dependencies": { "undici-types": "~7.14.0" } }, "sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw=="],
+    "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
-    "@types/react": ["@types/react@19.2.2", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA=="],
-
-    "bun-types": ["bun-types@1.2.23", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw=="],
-
-    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
-    "opencode-ai": ["opencode-ai@0.14.6", "", { "optionalDependencies": { "opencode-darwin-arm64": "0.14.6", "opencode-darwin-x64": "0.14.6", "opencode-darwin-x64-baseline": "0.14.6", "opencode-linux-arm64": "0.14.6", "opencode-linux-x64": "0.14.6", "opencode-linux-x64-baseline": "0.14.6", "opencode-windows-x64": "0.14.6" }, "bin": { "opencode": "bin/opencode" } }, "sha512-BJA5j2unJjwBDqa4j9ozYX3oNsX2FSIh+0mlf/Q1jrKfHkvqfnY8i2Yr3j1vNRCRafmi/KQer8KatbOjmyJ8cw=="],
+    "opencode-ai": ["opencode-ai@1.14.48", "", { "optionalDependencies": { "opencode-darwin-arm64": "1.14.48", "opencode-darwin-x64": "1.14.48", "opencode-darwin-x64-baseline": "1.14.48", "opencode-linux-arm64": "1.14.48", "opencode-linux-arm64-musl": "1.14.48", "opencode-linux-x64": "1.14.48", "opencode-linux-x64-baseline": "1.14.48", "opencode-linux-x64-baseline-musl": "1.14.48", "opencode-linux-x64-musl": "1.14.48", "opencode-windows-arm64": "1.14.48", "opencode-windows-x64": "1.14.48", "opencode-windows-x64-baseline": "1.14.48" }, "bin": { "opencode": "bin/opencode" } }, "sha512-65ogCJao8ujS4gFP64QuStv/h+qII30xNiARGsu9ai8Uoj+a/m6gz8yhNC9oz1dZm7PF6n15iIpB/LzCXBrhZQ=="],
 
-    "opencode-darwin-arm64": ["opencode-darwin-arm64@0.14.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gOH91wwOSf+6mhWEWi6+/Og0qZf+qlA/dC6ItTR5cPxNHDphERvdOP6xyjNfBGiU5xuCDorljkNGa31Pju5ftw=="],
+    "opencode-darwin-arm64": ["opencode-darwin-arm64@1.14.48", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QF05WtuPVnXCkvBHdDSuIhHVgYb/f10HO2mRlUbbBWStbPedLWwOKC4YKUhpsrLAVBEFLcL/xh7RtPM70+0TZQ=="],
 
-    "opencode-darwin-x64": ["opencode-darwin-x64@0.14.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-F85xyxozwuEcvQP2Okr2yUMVUZnhSV93fVRn1uqJselasHOvz8cUE1XP0JDLuafY8QGzEF399m+HfRJq4TBK1A=="],
+    "opencode-darwin-x64": ["opencode-darwin-x64@1.14.48", "", { "os": "darwin", "cpu": "x64" }, "sha512-Yx0/opXz7cdne1Xi77TNTIwWpYSwv+T32PdEcyqrcgEx0NR5f4S4kEsydmKsV7lzFRSkqRXniwvLj+8BPJEwNA=="],
 
-    "opencode-darwin-x64-baseline": ["opencode-darwin-x64-baseline@0.14.6", "", { "os": "darwin", "cpu": "none" }, "sha512-RnMsInuP9q0YWkLBoUj2w6C/vySWqShDDw3XR2QVVg2PBeTH5IDeIEoO/fKdPAybyVwGWMz0xAHMWRPn6+Dm0w=="],
+    "opencode-darwin-x64-baseline": ["opencode-darwin-x64-baseline@1.14.48", "", { "os": "darwin", "cpu": "x64" }, "sha512-F3p1GRuPR+HKDVIGn/uS9N0685BQ1msOOZsYHiAc4Qe22ZhZGrnMveg4CZwDseAQxoFL5n29i9J7iw/QORmO/g=="],
 
-    "opencode-linux-arm64": ["opencode-linux-arm64@0.14.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-T76Pd6+LQZjH9JNLQqCmKhG301ACyB3luMsGu0+cGufG7aGSQ1M73wqbAmyglP6N0hAFB+ms1umFuLNUmTFU/A=="],
+    "opencode-linux-arm64": ["opencode-linux-arm64@1.14.48", "", { "os": "linux", "cpu": "arm64" }, "sha512-DPZUi4IErlM/oXbNQKOiAqlmIij322sGUewNkvn+UptZtoqMVjtM8UQc6RkfoSQtAhk9zfdXTRjmajXpSSPJTA=="],
 
-    "opencode-linux-x64": ["opencode-linux-x64@0.14.6", "", { "os": "linux", "cpu": "x64" }, "sha512-ywMQe9qJVcXDptRVCf4BmLxtMPxIshdn3opD1usDylLccGQMyQwVsacp8dpcWV74NX2cehyoK2ojk7N81tRVSw=="],
+    "opencode-linux-arm64-musl": ["opencode-linux-arm64-musl@1.14.48", "", { "os": "linux", "cpu": "arm64" }, "sha512-w+wY4ROlq6lpL+SPYLYHBA6k+twVU9kurBGt+6irf4ZA5BCkhva7mgRET4NBxheUKEPSEQknq3Umi2Ltab4G+w=="],
 
-    "opencode-linux-x64-baseline": ["opencode-linux-x64-baseline@0.14.6", "", { "os": "linux", "cpu": "none" }, "sha512-FKXihyr2yTL4++Hm9yTIhZkksT1Jg6e6n50in4Zy8A1qAFxHpx9peBk/Bf5Dl2PeMT9/E6kNq28rW8lU4dEo/g=="],
+    "opencode-linux-x64": ["opencode-linux-x64@1.14.48", "", { "os": "linux", "cpu": "x64" }, "sha512-WLAABtQD2Zr1+7zfGRcNYdAKYtr2EuMY6RwjoNRAqHzQslOlItZhDpwdqg03YFe0zrQhg0IlK6iGuplF1ertdw=="],
 
-    "opencode-windows-x64": ["opencode-windows-x64@0.14.6", "", { "os": "win32", "cpu": "x64" }, "sha512-0sX5Jk8Nyk923H1VW7NZqcp9UuQ/nX89QR5vB+cK3rP1VRdIbArWdZ/oBDnpd56w6x0UeLCijsa9tLDtvt9i3A=="],
+    "opencode-linux-x64-baseline": ["opencode-linux-x64-baseline@1.14.48", "", { "os": "linux", "cpu": "x64" }, "sha512-I8KoLTSpCYkChdosh2iFfXO0zwPuAp7ZbPZyzPN9R0jTW95EstO5qYPTLs8F+sZJiM+oUdxOEpgIVkGF6JMzAg=="],
+
+    "opencode-linux-x64-baseline-musl": ["opencode-linux-x64-baseline-musl@1.14.48", "", { "os": "linux", "cpu": "x64" }, "sha512-92icmlOdDHLm0ityztGHGlgv6OiqQTdXYZRsPUs17IcHlkxLUT2b5O8HUpHk/xtMwyJEleYpV3E5EQz4vP5HVw=="],
+
+    "opencode-linux-x64-musl": ["opencode-linux-x64-musl@1.14.48", "", { "os": "linux", "cpu": "x64" }, "sha512-h2QPam8t++TEphKm8zroxfuDZk8oAF40aKFxH753XrINfCAyRikOb/hNfLJd0J3oAcolxMbFHjr6c35zyJbzHQ=="],
+
+    "opencode-windows-arm64": ["opencode-windows-arm64@1.14.48", "", { "os": "win32", "cpu": "arm64" }, "sha512-WqcJHoxI3e06So6g83tKuyAGYXHp++/urLtojw78HDhV0RlO9Sthbv19YRu9gqp/GLYNqNChU5JLjVYFmoegkg=="],
+
+    "opencode-windows-x64": ["opencode-windows-x64@1.14.48", "", { "os": "win32", "cpu": "x64" }, "sha512-dq5glnTtVjd5sJJcQWpcSHTHj4x9hKsBTFSvGV7tV+FoBTQFsnPtCFqt6Wmo/s0D0VYQsMz/syY1YGtrA+O3pA=="],
+
+    "opencode-windows-x64-baseline": ["opencode-windows-x64-baseline@1.14.48", "", { "os": "win32", "cpu": "x64" }, "sha512-3RC6Pq/9yJn4jnWjOdDbJPJgIoMXRmWr4AytNeBwi7NifTBGmGnqxU+mFRWYJxJmCIvyWxHw/iVfEUtoej7/JQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici-types": ["undici-types@7.14.0", "", {}, "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="],
+    "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "opencode-codex-provider",
       "devDependencies": {
+        "@opencode-ai/plugin": "^1.14.48",
         "@types/bun": "^1.2.21",
         "typescript": "^5.8.2",
       },
@@ -17,13 +18,55 @@
   "packages": {
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
+
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="],
+
+    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
+
+    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
+
+    "@opencode-ai/plugin": ["@opencode-ai/plugin@1.14.48", "", { "dependencies": { "@opencode-ai/sdk": "1.14.48", "effect": "4.0.0-beta.59", "zod": "4.1.8" }, "peerDependencies": { "@opentui/core": ">=0.2.6", "@opentui/keymap": ">=0.2.6", "@opentui/solid": ">=0.2.6" }, "optionalPeers": ["@opentui/core", "@opentui/keymap", "@opentui/solid"] }, "sha512-pb2ywByzn4i35WWJquEYyb8lDC/ph1PLXT+heucJN6Y9U/oeSw98JQV93IG7M6BUBks6MKD3DGDJdQfyD6x0rA=="],
+
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.48", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-wKM86jCzV/ZApyWrdm3uP8XdWcS0LMbu3FV+OWz1ChiGGg1wiIWNGMJs5CY8/QX2/rUuZrd1Q1DqvdamZ0zLeg=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.7.0", "", { "dependencies": { "undici-types": "~7.21.0" } }, "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
+
+    "fast-check": ["fast-check@4.8.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg=="],
+
+    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
+    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
+
+    "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
+
+    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
+    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "opencode-ai": ["opencode-ai@1.14.48", "", { "optionalDependencies": { "opencode-darwin-arm64": "1.14.48", "opencode-darwin-x64": "1.14.48", "opencode-darwin-x64-baseline": "1.14.48", "opencode-linux-arm64": "1.14.48", "opencode-linux-arm64-musl": "1.14.48", "opencode-linux-x64": "1.14.48", "opencode-linux-x64-baseline": "1.14.48", "opencode-linux-x64-baseline-musl": "1.14.48", "opencode-linux-x64-musl": "1.14.48", "opencode-windows-arm64": "1.14.48", "opencode-windows-x64": "1.14.48", "opencode-windows-x64-baseline": "1.14.48" }, "bin": { "opencode": "bin/opencode" } }, "sha512-65ogCJao8ujS4gFP64QuStv/h+qII30xNiARGsu9ai8Uoj+a/m6gz8yhNC9oz1dZm7PF6n15iIpB/LzCXBrhZQ=="],
 
@@ -51,8 +94,26 @@
 
     "opencode-windows-x64-baseline": ["opencode-windows-x64-baseline@1.14.48", "", { "os": "win32", "cpu": "x64" }, "sha512-3RC6Pq/9yJn4jnWjOdDbJPJgIoMXRmWr4AytNeBwi7NifTBGmGnqxU+mFRWYJxJmCIvyWxHw/iVfEUtoej7/JQ=="],
 
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "toml": ["toml@4.1.1", "", {}, "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.21.0", "", {}, "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="],
+
+    "uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -55,8 +55,10 @@ export const CodexProviderPlugin: Plugin = async () => {
         options,
       }
     },
-    "chat.params": async (_input: { sessionID: string; agent: string; model: unknown; provider: unknown; message: unknown }, output: { temperature: number; topP: number; topK: number; maxOutputTokens: number | undefined; options: Record<string, unknown> }) => {
-      output.maxOutputTokens = undefined
+    "chat.params": async (_input: { sessionID: string; agent: string; model: unknown; provider: { source: string; info: { id: string }; options: Record<string, unknown> }; message: unknown }, output: { temperature: number; topP: number; topK: number; maxOutputTokens: number | undefined; options: Record<string, unknown> }) => {
+      if (_input.provider?.info?.id === "codex") {
+        output.maxOutputTokens = undefined
+      }
     },
   } satisfies Hooks
 }

--- a/index.ts
+++ b/index.ts
@@ -9,8 +9,21 @@ export { createCodexProvider }
 export const CodexProviderPlugin: Plugin = async () => {
   const providerNpm = PACKAGE_NAME
   const defaultModels = {
-    "gpt-5-codex": { name: "GPT-5 Codex", reasoning: true },
-    "gpt-5": { name: "GPT-5", reasoning: true }
+    "gpt-5.5": {
+      name: "GPT-5.5",
+      reasoning: true,
+      limit: { context: 258400, output: 128000 },
+    },
+    "gpt-5.4": {
+      name: "GPT-5.4",
+      reasoning: true,
+      limit: { context: 128000, output: 16384 },
+    },
+    "gpt-5.2": {
+      name: "GPT-5.2",
+      reasoning: true,
+      limit: { context: 128000, output: 16384 },
+    },
   } satisfies Record<string, Record<string, unknown>>
 
   return {
@@ -39,6 +52,9 @@ export const CodexProviderPlugin: Plugin = async () => {
         models: existingModels,
         options,
       }
+    },
+    "chat.params": async (_input, output) => {
+      output.maxOutputTokens = undefined
     },
   } satisfies Hooks
 }

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import type { Plugin, Hooks } from "@opencode-ai/plugin"
+import type { Plugin, Hooks, Config } from "@opencode-ai/plugin"
 import { createCodexProvider } from "./src/codexProvider"
 import { fileURLToPath } from "node:url"
 
@@ -27,12 +27,14 @@ export const CodexProviderPlugin: Plugin = async () => {
   } satisfies Record<string, Record<string, unknown>>
 
   return {
-    async config(config) {
-      config.provider = config.provider ?? {}
-      const existing = config.provider["codex"] ?? {}
+    async config(input: Config) {
+      const config = input as Record<string, unknown>
+      const providers = (config.provider ?? {}) as Record<string, Record<string, unknown>>
+      config.provider = providers
+      const existing = (providers["codex"] ?? {}) as Record<string, unknown>
       const options = {
-        ...(existing.options ?? {}),
-      }
+        ...((existing.options as Record<string, unknown>) ?? {}),
+      } as Record<string, unknown>
       if (!options.providerFactory) {
         const isFileProtocol = import.meta.url.startsWith("file://")
         if (isFileProtocol) {
@@ -45,7 +47,7 @@ export const CodexProviderPlugin: Plugin = async () => {
         ...defaultModels,
         ...(existing.models ?? {}),
       }
-      config.provider["codex"] = {
+      providers["codex"] = {
         ...existing,
         npm: existing.npm ?? providerNpm,
         name: existing.name ?? "Codex CLI",
@@ -53,7 +55,7 @@ export const CodexProviderPlugin: Plugin = async () => {
         options,
       }
     },
-    "chat.params": async (_input, output) => {
+    "chat.params": async (_input: { sessionID: string; agent: string; model: unknown; provider: unknown; message: unknown }, output: { temperature: number; topP: number; topK: number; maxOutputTokens: number | undefined; options: Record<string, unknown> }) => {
       output.maxOutputTokens = undefined
     },
   } satisfies Hooks

--- a/opencode.json
+++ b/opencode.json
@@ -4,11 +4,17 @@
     "codex": {
       "name": "Codex CLI",
       "models": {
-        "gpt-5-codex": {
-          "name": "GPT-5-Codex"
+        "gpt-5.5": {
+          "name": "GPT-5.5",
+          "limit": { "context": 258400, "output": 128000 }
         },
-        "gpt-5": {
-          "name": "GPT-5"
+        "gpt-5.4": {
+          "name": "GPT-5.4",
+          "limit": { "context": 128000, "output": 16384 }
+        },
+        "gpt-5.2": {
+          "name": "GPT-5.2",
+          "limit": { "context": 128000, "output": 16384 }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@ai-sdk/provider": "3.0.8"
 	},
 	"devDependencies": {
+		"@opencode-ai/plugin": "^1.14.48",
 		"@types/bun": "^1.2.21",
 		"typescript": "^5.8.2"
 	},

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"peerDependencies": {
 		"opencode-ai": ">=0.14.4",
-		"@ai-sdk/provider": "3.0.8"
+		"@ai-sdk/provider": "^3.0.0"
 	},
 	"devDependencies": {
 		"@opencode-ai/plugin": "^1.14.48",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	},
 	"peerDependencies": {
 		"opencode-ai": ">=0.14.4",
-		"@ai-sdk/provider": ">=2.0.0"
+		"@ai-sdk/provider": "3.0.8"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.2.21",

--- a/src/codexProvider.ts
+++ b/src/codexProvider.ts
@@ -45,6 +45,7 @@ class CodexLanguageModel implements LanguageModelV3 {
     const { stream } = await this.doStream(options)
     const reader = stream.getReader()
     let text = ""
+    let finishReason: import("@ai-sdk/provider").LanguageModelV3FinishReason = { unified: "stop", raw: undefined }
     let usage: LanguageModelV3Usage = {
       inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
       outputTokens: { total: undefined, text: undefined, reasoning: undefined },
@@ -63,6 +64,7 @@ class CodexLanguageModel implements LanguageModelV3 {
         case "error":
           throw value.error instanceof Error ? value.error : new Error(String(value.error))
         case "finish":
+          finishReason = value.finishReason
           usage = value.usage
           providerMetadata = value.providerMetadata
           break
@@ -75,7 +77,7 @@ class CodexLanguageModel implements LanguageModelV3 {
 
     return {
       content,
-      finishReason: { unified: "stop", raw: undefined },
+      finishReason,
       usage,
       providerMetadata,
       warnings: [],

--- a/src/codexProvider.ts
+++ b/src/codexProvider.ts
@@ -56,7 +56,9 @@ class CodexLanguageModel implements LanguageModelV3 {
       if (done) break
       switch (value.type) {
         case "text-delta":
-          text += value.delta
+          if (value.id === "codex-text") {
+            text += value.delta
+          }
           break
         case "error":
           throw value.error instanceof Error ? value.error : new Error(String(value.error))

--- a/src/codexProvider.ts
+++ b/src/codexProvider.ts
@@ -5,10 +5,8 @@ import type {
   LanguageModelV3StreamPart,
   LanguageModelV3GenerateResult,
   LanguageModelV3StreamResult,
-  LanguageModelV3FinishReason,
   LanguageModelV3Usage,
   ProviderV3,
-  SharedV3Headers,
 } from "@ai-sdk/provider"
 import { CodexMCPClient } from "./codexClient"
 import { codexLog } from "./logger"
@@ -23,11 +21,6 @@ import {
   mapSandboxMode,
   sharedPrefixLength,
 } from "./utils"
-
-const NULL_V3_USAGE: LanguageModelV3Usage = {
-  inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
-  outputTokens: { total: undefined, text: undefined, reasoning: undefined },
-}
 
 class CodexLanguageModel implements LanguageModelV3 {
   readonly specificationVersion = "v3" as const
@@ -52,6 +45,11 @@ class CodexLanguageModel implements LanguageModelV3 {
     const { stream } = await this.doStream(options)
     const reader = stream.getReader()
     let text = ""
+    let usage: LanguageModelV3Usage = {
+      inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+      outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+    }
+    let providerMetadata: import("@ai-sdk/provider").SharedV3ProviderMetadata | undefined
 
     while (true) {
       const { value, done } = await reader.read()
@@ -62,6 +60,10 @@ class CodexLanguageModel implements LanguageModelV3 {
           break
         case "error":
           throw value.error instanceof Error ? value.error : new Error(String(value.error))
+        case "finish":
+          usage = value.usage
+          providerMetadata = value.providerMetadata
+          break
       }
     }
 
@@ -72,7 +74,8 @@ class CodexLanguageModel implements LanguageModelV3 {
     return {
       content,
       finishReason: { unified: "stop", raw: undefined },
-      usage: NULL_V3_USAGE,
+      usage,
+      providerMetadata,
       warnings: [],
     }
   }
@@ -99,9 +102,9 @@ class CodexLanguageModel implements LanguageModelV3 {
       "approval-policy": approvalPolicy,
       sandbox,
       "include-plan-tool": false,
-      config: {
-        model_reasoning_effort: reasoningEffort,
-      },
+    }
+    if (reasoningEffort) {
+      toolArgs["config"] = { model_reasoning_effort: reasoningEffort }
     }
 
     const client = new CodexMCPClient(
@@ -148,7 +151,7 @@ class CodexLanguageModel implements LanguageModelV3 {
           const type = typeof msg.type === "string" ? msg.type : notification.method.split("/").at(-1) ?? ""
 
           if (type === "agent_message_delta" && typeof msg.delta === "string" && msg.delta) {
-            streamState.pushDelta("text", msg.delta, "agent_message_delta")
+            streamState.pushDelta("text", msg.delta)
             lastAgentMessage = `${lastAgentMessage}${msg.delta}`
             return
           }
@@ -163,14 +166,14 @@ class CodexLanguageModel implements LanguageModelV3 {
             const prefixLength = sharedPrefixLength(lastAgentMessage, message)
             const delta = message.slice(prefixLength)
             if (delta) {
-              streamState.pushDelta("text", delta, "agent_message_delta_from_full")
+              streamState.pushDelta("text", delta)
             }
             lastAgentMessage = message
             return
           }
 
           if (includeReasoning && type === "agent_reasoning_delta" && typeof msg.delta === "string" && msg.delta) {
-            streamState.pushReasoning(msg.delta, "agent_reasoning_delta")
+            streamState.pushReasoning(msg.delta)
             lastReasoningMessage = `${lastReasoningMessage}${msg.delta}`
             return
           }
@@ -182,14 +185,14 @@ class CodexLanguageModel implements LanguageModelV3 {
               return
             }
             if (!streamState.reasoningDeltaSeen) {
-              streamState.pushReasoning(text, "agent_reasoning")
+              streamState.pushReasoning(text)
             }
             lastReasoningMessage = text
             return
           }
 
           if (includeReasoning && type === "agent_reasoning_section_break") {
-            streamState.pushReasoning("\n", "agent_reasoning_section_break")
+            streamState.pushReasoning("\n")
             lastReasoningMessage = `${lastReasoningMessage}\n`
             return
           }
@@ -197,12 +200,31 @@ class CodexLanguageModel implements LanguageModelV3 {
           if (includeCommandOutput && type === "exec_command_output_delta" && typeof msg.chunk === "string") {
             const decoded = decodeExecChunk(msg.chunk)
             if (decoded) {
-              streamState.pushDelta("exec", decoded, "exec_command_output_delta")
+              streamState.pushDelta("exec", decoded)
             }
             return
           }
 
+          if (type === "token_count") {
+            codexLog("token_count", { hasUsage: !!msg.info?.total_token_usage, inputTokens: msg.info?.total_token_usage?.input_tokens, outputTokens: msg.info?.total_token_usage?.output_tokens })
+            streamState.updateTokenUsage(msg.info ?? null, msg.rate_limits ?? null)
+            return
+          }
+
+          if (type === "session_configured" && msg.model) {
+            codexLog("session_configured", { model: msg.model })
+            streamState.emitResponseMetadata({ modelId: String(msg.model) })
+            return
+          }
+
           if (type === "task_complete") {
+            codexLog("task_complete", { duration_ms: msg.duration_ms, time_to_first_token_ms: msg.time_to_first_token_ms })
+            if (msg.duration_ms != null || msg.time_to_first_token_ms != null) {
+              streamState.updateTaskTiming({
+                duration_ms: typeof msg.duration_ms === "number" ? msg.duration_ms : undefined,
+                time_to_first_token_ms: typeof msg.time_to_first_token_ms === "number" ? msg.time_to_first_token_ms : undefined,
+              })
+            }
             finishedViaNotification = true
             streamState.finish("stop")
             return
@@ -275,7 +297,7 @@ class CodexLanguageModel implements LanguageModelV3 {
             const prefixLength = sharedPrefixLength(lastAgentMessage, text)
             const delta = text.slice(prefixLength)
             if (delta) {
-              streamState.pushDelta("text", delta, "call_result")
+              streamState.pushDelta("text", delta)
             }
           }
           streamState.finish("stop")

--- a/src/codexProvider.ts
+++ b/src/codexProvider.ts
@@ -1,12 +1,14 @@
 import type {
-  LanguageModelV2,
-  LanguageModelV2CallOptions,
-  LanguageModelV2Content,
-  LanguageModelV2FinishReason,
-  LanguageModelV2StreamPart,
-  LanguageModelV2Usage,
-  SharedV2Headers,
-  ProviderV2,
+  LanguageModelV3,
+  LanguageModelV3CallOptions,
+  LanguageModelV3Content,
+  LanguageModelV3StreamPart,
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamResult,
+  LanguageModelV3FinishReason,
+  LanguageModelV3Usage,
+  ProviderV3,
+  SharedV3Headers,
 } from "@ai-sdk/provider"
 import { CodexMCPClient } from "./codexClient"
 import { codexLog } from "./logger"
@@ -22,8 +24,13 @@ import {
   sharedPrefixLength,
 } from "./utils"
 
-class CodexLanguageModel implements LanguageModelV2 {
-  readonly specificationVersion = "v2" as const
+const NULL_V3_USAGE: LanguageModelV3Usage = {
+  inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+}
+
+class CodexLanguageModel implements LanguageModelV3 {
+  readonly specificationVersion = "v3" as const
   readonly provider = "codex"
   readonly supportedUrls: Record<string, RegExp[]> = { "*/*": [] }
 
@@ -41,12 +48,10 @@ class CodexLanguageModel implements LanguageModelV2 {
     return this.modelId
   }
 
-  async doGenerate(options: LanguageModelV2CallOptions) {
+  async doGenerate(options: LanguageModelV3CallOptions): Promise<LanguageModelV3GenerateResult> {
     const { stream } = await this.doStream(options)
     const reader = stream.getReader()
     let text = ""
-    let finishReason: LanguageModelV2FinishReason = "stop"
-    let usage: LanguageModelV2Usage | undefined
 
     while (true) {
       const { value, done } = await reader.read()
@@ -55,44 +60,24 @@ class CodexLanguageModel implements LanguageModelV2 {
         case "text-delta":
           text += value.delta
           break
-        case "finish":
-          finishReason = value.finishReason
-          usage = value.usage
-          break
         case "error":
           throw value.error instanceof Error ? value.error : new Error(String(value.error))
       }
     }
 
-    const content: LanguageModelV2Content[] = text
-      ? [
-          {
-            type: "text",
-            text,
-          },
-        ]
+    const content: LanguageModelV3Content[] = text
+      ? [{ type: "text", text }]
       : []
 
     return {
       content,
-      finishReason,
-      usage:
-        usage ?? {
-          inputTokens: undefined,
-          outputTokens: undefined,
-          totalTokens: undefined,
-        },
+      finishReason: { unified: "stop", raw: undefined },
+      usage: NULL_V3_USAGE,
       warnings: [],
     }
   }
 
-  async doStream(
-    options: LanguageModelV2CallOptions,
-  ): Promise<{
-    stream: ReadableStream<LanguageModelV2StreamPart>
-    request?: { body?: unknown }
-    response?: { headers?: SharedV2Headers }
-  }> {
+  async doStream(options: LanguageModelV3CallOptions): Promise<LanguageModelV3StreamResult> {
     const providerOptions = this.extractProviderOptions(options)
     const { baseInstructions, userText, assistantText } = buildConversationPayload(options.prompt)
     let prompt = userText || "Please respond to the request."
@@ -132,7 +117,7 @@ class CodexLanguageModel implements LanguageModelV2 {
       },
     )
 
-    const stream = new ReadableStream<LanguageModelV2StreamPart>({
+    const stream = new ReadableStream<LanguageModelV3StreamPart>({
       start: async (controller) => {
         const streamState = new StreamState(controller, client, providerOptions.streamReasoning ?? true)
         let finishedViaNotification = false
@@ -219,9 +204,6 @@ class CodexLanguageModel implements LanguageModelV2 {
 
           if (type === "task_complete") {
             finishedViaNotification = true
-            // if (typeof msg.last_agent_message === "string" && msg.last_agent_message && msg.last_agent_message.trim()) {
-            //   streamState.pushDelta("text", msg.last_agent_message, "task_complete")
-            // }
             streamState.finish("stop")
             return
           }
@@ -320,18 +302,19 @@ class CodexLanguageModel implements LanguageModelV2 {
     return { stream }
   }
 
-  private extractProviderOptions(options: LanguageModelV2CallOptions): CodexProviderOptions {
+  private extractProviderOptions(options: LanguageModelV3CallOptions): CodexProviderOptions {
     const providerSpecific =
       ((options.providerOptions ?? {}) as Record<string, CodexProviderOptions | undefined>)[this.provider] ?? {}
     return providerSpecific
   }
 }
 
-export function createCodexProvider(): ProviderV2 {
+export function createCodexProvider(): ProviderV3 {
   return {
+    specificationVersion: "v3",
     languageModel: (modelId: string) => new CodexLanguageModel(modelId),
-    textEmbeddingModel: (modelId:string) => {
-      throw new Error(`Codex provider does not support text embeddings (requested model: ${modelId})`)
+    embeddingModel: (modelId: string) => {
+      throw new Error(`Codex provider does not support embedding models (requested model: ${modelId})`)
     },
     imageModel: (modelId: string) => {
       throw new Error(`Codex provider does not support image models (requested model: ${modelId})`)

--- a/src/monkeyPatch.ts
+++ b/src/monkeyPatch.ts
@@ -247,7 +247,7 @@ class CustomModelNotFoundError extends Error {
 }
 
 class CustomInitError extends Error {
-  public cause?: Error
+  public override cause?: Error
   
   constructor(params: { providerID: string }, options?: { cause?: Error }) {
     let message = `Init error for provider ${params.providerID}`

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -1,12 +1,21 @@
-import type { LanguageModelV3StreamPart, LanguageModelV3FinishReason } from "@ai-sdk/provider";
+import type { LanguageModelV3StreamPart, LanguageModelV3FinishReason, LanguageModelV3Usage, SharedV3ProviderMetadata } from "@ai-sdk/provider";
 import { CodexMCPClient } from "./codexClient";
 
 type StreamType = "text" | "exec" | "reasoning";
 
-const NULL_V3_USAGE = {
-  inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
-  outputTokens: { total: undefined, text: undefined, reasoning: undefined },
-} as const;
+interface CodexTokenUsage {
+  input_tokens: number;
+  cached_input_tokens: number;
+  output_tokens: number;
+  reasoning_output_tokens: number;
+  total_tokens: number;
+}
+
+interface CodexRateLimits {
+  plan_type?: string;
+  primary?: { used_percent: number; window_minutes: number; resets_at: number };
+  secondary?: { used_percent: number; window_minutes: number; resets_at: number };
+}
 
 export class StreamState {
   private finished = false;
@@ -15,11 +24,57 @@ export class StreamState {
   private lastReasoningNormalized = "";
   public reasoningDeltaSeen = false;
 
+  private tokenUsage: CodexTokenUsage | undefined;
+  private rateLimits: CodexRateLimits | undefined;
+  private taskTiming: { duration_ms?: number; time_to_first_token_ms?: number } = {};
+
   constructor(
     private readonly controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
     private readonly client: CodexMCPClient,
     private readonly includeReasoning: boolean,
   ) {}
+
+  public updateTokenUsage(info: { total_token_usage?: CodexTokenUsage; last_token_usage?: CodexTokenUsage } | null, rateLimits?: CodexRateLimits | null) {
+    if (!info) return;
+    const usage = info.total_token_usage ?? info.last_token_usage;
+    if (usage) {
+      this.tokenUsage = usage;
+    }
+    if (rateLimits) {
+      this.rateLimits = rateLimits;
+    }
+  }
+
+  public updateTaskTiming(timing: { duration_ms?: number; time_to_first_token_ms?: number }) {
+    this.taskTiming = { ...this.taskTiming, ...timing };
+  }
+
+  private buildUsage(): LanguageModelV3Usage {
+    const u = this.tokenUsage;
+    if (!u) {
+      return {
+        inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+        outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+      };
+    }
+    const nonCached = u.input_tokens - u.cached_input_tokens;
+    return {
+      inputTokens: { total: u.input_tokens, noCache: nonCached, cacheRead: u.cached_input_tokens, cacheWrite: undefined },
+      outputTokens: { total: u.output_tokens, text: undefined, reasoning: u.reasoning_output_tokens || undefined },
+    };
+  }
+
+  private buildProviderMetadata(): SharedV3ProviderMetadata | undefined {
+    const meta: Record<string, unknown> = {};
+    if (this.taskTiming.duration_ms !== undefined || this.taskTiming.time_to_first_token_ms !== undefined) {
+      meta.timing = { ...this.taskTiming };
+    }
+    if (this.rateLimits) {
+      meta.rateLimits = JSON.parse(JSON.stringify(this.rateLimits));
+    }
+    if (Object.keys(meta).length === 0) return undefined;
+    return { codex: JSON.parse(JSON.stringify(meta)) } as SharedV3ProviderMetadata;
+  }
 
   public finish(reason: LanguageModelV3FinishReason["unified"], error?: Error) {
     if (this.finished) return;
@@ -36,11 +91,19 @@ export class StreamState {
     this.controller.enqueue({
       type: "finish",
       finishReason: { unified: reason, raw: undefined },
-      usage: NULL_V3_USAGE,
+      usage: this.buildUsage(),
+      providerMetadata: this.buildProviderMetadata(),
     });
 
     this.controller.close();
     this.client.close();
+  }
+
+  public emitResponseMetadata(meta: { id?: string; modelId?: string }) {
+    const event: LanguageModelV3StreamPart = { type: "response-metadata" };
+    // LanguageModelV3ResponseMetadata fields are mixed in directly
+    const enriched = { ...event, ...meta };
+    this.controller.enqueue(enriched as LanguageModelV3StreamPart);
   }
 
   public ensureStreamStart(type: StreamType) {
@@ -61,7 +124,7 @@ export class StreamState {
     return value.trim().replace(/\*/g, "").replace(/\s+/g, " ");
   }
 
-  public pushReasoning(chunk: string, source?: string) {
+  public pushReasoning(chunk: string) {
     if (!chunk || !this.includeReasoning) return;
     const normalized = this.normalizeReasoning(chunk);
     if (!normalized && chunk === "\n" && this.lastReasoningChunk === "\n") {
@@ -74,14 +137,14 @@ export class StreamState {
       return;
     }
     this.reasoningDeltaSeen = true;
-    this.pushDelta("reasoning", chunk, source);
+    this.pushDelta("reasoning", chunk);
     this.lastReasoningChunk = chunk;
     if (normalized) {
       this.lastReasoningNormalized = normalized;
     }
   }
 
-  public pushDelta(type: StreamType, delta: string, source?: string) {
+  public pushDelta(type: StreamType, delta: string) {
     if (!delta) return;
     if (type === "reasoning" && !this.includeReasoning) return;
 

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -1,7 +1,12 @@
-import { LanguageModelV2FinishReason, LanguageModelV2StreamPart } from "@ai-sdk/provider";
+import type { LanguageModelV3StreamPart, LanguageModelV3FinishReason } from "@ai-sdk/provider";
 import { CodexMCPClient } from "./codexClient";
 
 type StreamType = "text" | "exec" | "reasoning";
+
+const NULL_V3_USAGE = {
+  inputTokens: { total: undefined, noCache: undefined, cacheRead: undefined, cacheWrite: undefined },
+  outputTokens: { total: undefined, text: undefined, reasoning: undefined },
+} as const;
 
 export class StreamState {
   private finished = false;
@@ -11,12 +16,12 @@ export class StreamState {
   public reasoningDeltaSeen = false;
 
   constructor(
-    private readonly controller: ReadableStreamDefaultController<LanguageModelV2StreamPart>,
+    private readonly controller: ReadableStreamDefaultController<LanguageModelV3StreamPart>,
     private readonly client: CodexMCPClient,
     private readonly includeReasoning: boolean,
   ) {}
 
-  public finish(reason: LanguageModelV2FinishReason, error?: Error) {
+  public finish(reason: LanguageModelV3FinishReason["unified"], error?: Error) {
     if (this.finished) return;
     this.finished = true;
 
@@ -30,12 +35,8 @@ export class StreamState {
 
     this.controller.enqueue({
       type: "finish",
-      finishReason: reason,
-      usage: {
-        inputTokens: undefined,
-        outputTokens: undefined,
-        totalTokens: undefined,
-      },
+      finishReason: { unified: reason, raw: undefined },
+      usage: NULL_V3_USAGE,
     });
 
     this.controller.close();

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -35,10 +35,11 @@ export class StreamState {
   ) {}
 
   public updateTokenUsage(info: { total_token_usage?: CodexTokenUsage; last_token_usage?: CodexTokenUsage } | null, rateLimits?: CodexRateLimits | null) {
-    if (!info) return;
-    const usage = info.total_token_usage ?? info.last_token_usage;
-    if (usage) {
-      this.tokenUsage = usage;
+    if (info) {
+      const usage = info.total_token_usage ?? info.last_token_usage;
+      if (usage) {
+        this.tokenUsage = usage;
+      }
     }
     if (rateLimits) {
       this.rateLimits = rateLimits;
@@ -61,7 +62,7 @@ export class StreamState {
     const nonCached = Math.max(0, u.input_tokens - cached);
     return {
       inputTokens: { total: u.input_tokens, noCache: nonCached, cacheRead: Math.min(u.input_tokens, cached), cacheWrite: undefined },
-      outputTokens: { total: u.output_tokens, text: undefined, reasoning: u.reasoning_output_tokens || undefined },
+      outputTokens: { total: u.output_tokens, text: undefined, reasoning: u.reasoning_output_tokens ?? undefined },
     };
   }
 

--- a/src/stream-state.ts
+++ b/src/stream-state.ts
@@ -57,9 +57,10 @@ export class StreamState {
         outputTokens: { total: undefined, text: undefined, reasoning: undefined },
       };
     }
-    const nonCached = u.input_tokens - u.cached_input_tokens;
+    const cached = u.cached_input_tokens ?? 0;
+    const nonCached = Math.max(0, u.input_tokens - cached);
     return {
-      inputTokens: { total: u.input_tokens, noCache: nonCached, cacheRead: u.cached_input_tokens, cacheWrite: undefined },
+      inputTokens: { total: u.input_tokens, noCache: nonCached, cacheRead: Math.min(u.input_tokens, cached), cacheWrite: undefined },
       outputTokens: { total: u.output_tokens, text: undefined, reasoning: u.reasoning_output_tokens || undefined },
     };
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV2CallOptions } from "@ai-sdk/provider"
+import type { LanguageModelV3CallOptions } from "@ai-sdk/provider"
 import type { CodexProviderOptions, JsonValue } from "./types"
 
 export const DEFAULT_REASONING: CodexProviderOptions["reasoningEffort"] = "minimal"
@@ -80,7 +80,7 @@ export function extractTextFromParts(parts: any[]) {
   return textSegments.join("\n").trim()
 }
 
-export function buildConversationPayload(messages: LanguageModelV2CallOptions["prompt"]) {
+export function buildConversationPayload(messages: LanguageModelV3CallOptions["prompt"]) {
   const systemSegments: string[] = []
   const userSegments: string[] = []
   const assistantSegments: string[] = []

--- a/tests/fixtures/fixtures.test.ts
+++ b/tests/fixtures/fixtures.test.ts
@@ -94,8 +94,8 @@ describe("Test Fixtures", () => {
       const state = createMockState()
       
       expect(state.providers.codex).toBeDefined()
-      expect(state.providers.codex.options.providerFactory).toBe('opencode-codex-provider/provider')
-      expect(state.providers.codex.info.models['gpt-5-codex']).toBeDefined()
+      expect(state.providers.codex!.options.providerFactory).toBe('opencode-codex-provider/provider')
+      expect(state.providers.codex!.info.models['gpt-5-codex']).toBeDefined()
     })
 
     test("includes test providers when requested", () => {
@@ -126,8 +126,8 @@ describe("Test Fixtures", () => {
       const config = createMockConfig()
       
       expect(config.providers.codex).toBeDefined()
-      expect(config.providers.codex.providerFactory).toBe('opencode-codex-provider/provider')
-      expect(config.providers.codex.models['gpt-5-codex']).toBeDefined()
+      expect(config.providers.codex!.providerFactory).toBe('opencode-codex-provider/provider')
+      expect(config.providers.codex!.models['gpt-5-codex']).toBeDefined()
     })
 
     test("includes standard providers when requested", () => {
@@ -135,8 +135,8 @@ describe("Test Fixtures", () => {
       
       expect(config.providers.openai).toBeDefined()
       expect(config.providers.anthropic).toBeDefined()
-      expect(config.providers.openai.env).toContain('OPENAI_API_KEY')
-      expect(config.providers.anthropic.env).toContain('ANTHROPIC_API_KEY')
+      expect(config.providers.openai!.env).toContain('OPENAI_API_KEY')
+      expect(config.providers.anthropic!.env).toContain('ANTHROPIC_API_KEY')
     })
 
     test("applies custom factory configurations", () => {
@@ -150,8 +150,8 @@ describe("Test Fixtures", () => {
         customFactories 
       })
       
-      expect(config.providers.codex.providerFactory).toBe('custom-codex-factory')
-      expect(config.providers.openai.providerFactory).toBe('custom-openai-factory')
+      expect(config.providers.codex!.providerFactory).toBe('custom-codex-factory')
+      expect(config.providers.openai!.providerFactory).toBe('custom-openai-factory')
     })
   })
 
@@ -285,23 +285,23 @@ describe("Test Fixtures", () => {
       
       // Verify provider structure
       const codexProvider = state.providers.codex
-      expect(codexProvider.source).toBe('config')
-      expect(codexProvider.info.id).toBe('codex')
-      expect(codexProvider.info.models).toBeDefined()
-      expect(codexProvider.options.providerFactory).toBeDefined()
+      expect(codexProvider!.source).toBe('config')
+      expect(codexProvider!.info.id).toBe('codex')
+      expect(codexProvider!.info.models).toBeDefined()
+      expect(codexProvider!.options.providerFactory).toBeDefined()
     })
 
     test("mock config supports providerFactory configuration", () => {
       const config = createMockConfig()
       
       // Verify the config has providerFactory settings
-      expect(config.providers.codex.providerFactory).toBe('opencode-codex-provider/provider')
+      expect(config.providers.codex!.providerFactory).toBe('opencode-codex-provider/provider')
       
       // Test custom factory configuration
       const customConfig = createMockConfig({
         customFactories: { codex: 'custom/factory/path' }
       })
-      expect(customConfig.providers.codex.providerFactory).toBe('custom/factory/path')
+      expect(customConfig.providers.codex!.providerFactory).toBe('custom/factory/path')
     })
   })
 })

--- a/tests/fixtures/mock-config.ts
+++ b/tests/fixtures/mock-config.ts
@@ -331,6 +331,7 @@ export function createMockConfig(options: MockConfigOptions = {}): MockOpencodeC
   if (includeCodexProvider) {
     config.providers.codex = {
       ...DEFAULT_PROVIDERS.codex,
+      env: [...DEFAULT_PROVIDERS.codex.env],
       providerFactory: customFactories.codex || DEFAULT_PROVIDERS.codex.providerFactory
     }
   }
@@ -339,10 +340,12 @@ export function createMockConfig(options: MockConfigOptions = {}): MockOpencodeC
   if (includeStandardProviders) {
     config.providers.openai = {
       ...DEFAULT_PROVIDERS.openai,
+      env: [...DEFAULT_PROVIDERS.openai.env],
       providerFactory: customFactories.openai
     }
     config.providers.anthropic = {
       ...DEFAULT_PROVIDERS.anthropic,
+      env: [...DEFAULT_PROVIDERS.anthropic.env],
       providerFactory: customFactories.anthropic
     }
   }
@@ -438,7 +441,7 @@ export function createErrorMockConfig(errorType: 'no-providers' | 'invalid-facto
 
     case 'invalid-factory':
       const invalidConfig = createMockConfig({ includeCodexProvider: true })
-      invalidConfig.providers.codex.providerFactory = 'invalid/factory/module'
+      invalidConfig.providers.codex!.providerFactory = 'invalid/factory/module'
       return invalidConfig
 
     case 'missing-env':

--- a/tests/fixtures/mock-provider.ts
+++ b/tests/fixtures/mock-provider.ts
@@ -106,7 +106,7 @@ export class MockModelNotFoundError extends Error {
 }
 
 export class MockInitError extends Error {
-  public cause?: Error
+  public override cause?: Error
   
   constructor(params: { providerID: string }, options?: { cause?: Error }) {
     let message = `Init error for provider ${params.providerID}`

--- a/tests/fixtures/mock-state.ts
+++ b/tests/fixtures/mock-state.ts
@@ -217,13 +217,13 @@ export function createMockState(options: MockStateOptions = {}): MockState {
 
   // Add codex provider by default
   if (includeCodexProvider) {
-    state.providers.codex = DEFAULT_PROVIDERS.codex
+    state.providers.codex = { ...DEFAULT_PROVIDERS.codex, info: { ...DEFAULT_PROVIDERS.codex.info, env: [...DEFAULT_PROVIDERS.codex.info.env] } }
   }
 
   // Add additional test providers if requested
   if (includeTestProviders) {
-    state.providers.openai = DEFAULT_PROVIDERS.openai
-    state.providers.anthropic = DEFAULT_PROVIDERS.anthropic
+    state.providers.openai = { ...DEFAULT_PROVIDERS.openai, info: { ...DEFAULT_PROVIDERS.openai.info, env: [...DEFAULT_PROVIDERS.openai.info.env] } }
+    state.providers.anthropic = { ...DEFAULT_PROVIDERS.anthropic, info: { ...DEFAULT_PROVIDERS.anthropic.info, env: [...DEFAULT_PROVIDERS.anthropic.info.env] } }
   }
 
   // Pre-populate cache with test data if requested
@@ -307,7 +307,7 @@ export function createErrorMockState(errorType: 'empty' | 'missing-codex' | 'inv
     case 'invalid-factory':
       const state = createMockState()
       // Set invalid factory module path
-      state.providers.codex.options.providerFactory = 'invalid/module/path'
+      state.providers.codex!.options.providerFactory = 'invalid/module/path'
       return state
 
     case 'corrupted':

--- a/tests/integration/error-handling.test.ts
+++ b/tests/integration/error-handling.test.ts
@@ -103,8 +103,8 @@ describeOrSkip("Error Handling", () => {
       expect(true).toBe(false) // Should not reach here
     } catch (error) {
       expect(error).toBeInstanceOf(ProviderModule.Provider.ModelNotFoundError)
-      expect(error.message).toContain("nonexistent")
-      expect(error.message).toContain("model")
+      expect((error as Error).message).toContain("nonexistent")
+      expect((error as Error).message).toContain("model")
     }
   })
   
@@ -134,8 +134,8 @@ describeOrSkip("Error Handling", () => {
       expect(true).toBe(false) // Should not reach here
     } catch (error) {
       expect(error).toBeInstanceOf(ProviderModule.Provider.ModelNotFoundError)
-      expect(error.message).toContain("codex")
-      expect(error.message).toContain("nonexistent-model")
+      expect((error as Error).message).toContain("codex")
+      expect((error as Error).message).toContain("nonexistent-model")
     }
   })
   
@@ -183,9 +183,9 @@ describeOrSkip("Error Handling", () => {
         expect(true).toBe(false) // Should not reach here
       } catch (error) {
         expect(error).toBeInstanceOf(ProviderModule.Provider.InitError)
-        expect(error.message).toContain("codex")
-        expect(error.cause).toBeDefined()
-        expect(error.cause.message).toContain("createCodexProvider")
+        expect((error as Error).message).toContain("codex")
+        expect((error as Error).cause).toBeDefined()
+        expect(((error as Error).cause as Error).message).toContain("createCodexProvider")
       }
     } finally {
       // Restore original config
@@ -211,12 +211,15 @@ describeOrSkip("Error Handling", () => {
     const failingFactoryPath = "non-existent-factory-module"
     
     // Mock the import to throw an error
-    const originalImport = global.import
-    global.import = mock(async (path: string) => {
+    const originalImport = (globalThis as Record<string, unknown>)['import'] as ((path: string) => Promise<unknown>) | undefined
+    ;(globalThis as Record<string, unknown>)['import'] = mock(async (path: string) => {
       if (path === failingFactoryPath) {
         throw new Error(`Cannot resolve module '${path}'`)
       }
-      return originalImport(path)
+      if (originalImport) {
+        return originalImport(path)
+      }
+      return undefined
     })
     
     try {
@@ -255,7 +258,7 @@ describeOrSkip("Error Handling", () => {
         // Error should be caught and handled gracefully
         // Could be InitError or the original import error, depending on implementation
         expect(error).toBeDefined()
-        expect(error.message).toContain(failingFactoryPath)
+        expect((error as Error).message).toContain(failingFactoryPath)
       }
       
       // Restore original config
@@ -263,7 +266,7 @@ describeOrSkip("Error Handling", () => {
       
     } finally {
       // Restore original import
-      global.import = originalImport
+      ;(globalThis as Record<string, unknown>)['import'] = originalImport
     }
   })
 })

--- a/tests/integration/fixtures-integration.test.ts
+++ b/tests/integration/fixtures-integration.test.ts
@@ -101,9 +101,9 @@ describe("Integration Testing with Fixtures", () => {
     try {
       await failingProvider.Provider.getModel('codex', 'gpt-5-codex')
     } catch (error) {
-      expect(error.name).toBe('ProviderInitError')
-      expect(error.cause).toBeDefined()
-      expect(error.cause.message).toBe('Simulated factory import error')
+      expect((error as Error).name).toBe('ProviderInitError')
+      expect((error as Error).cause).toBeDefined()
+      expect(((error as Error).cause as Error).message).toBe('Simulated factory import error')
     }
   })
 

--- a/tests/integration/provider-loading.test.ts
+++ b/tests/integration/provider-loading.test.ts
@@ -152,7 +152,7 @@ describeOrSkip("Provider Loading Integration", () => {
     } catch (error) {
       // If the factory loading fails, that's still progress - the patch is applied
       // The factory might fail due to missing dependencies, but the logging should still occur
-      console.log("Factory loading failed (expected in test environment):", error.message)
+      console.log("Factory loading failed (expected in test environment):", (error as Error).message)
     }
   })
 })

--- a/tests/performance/benchmark.test.ts
+++ b/tests/performance/benchmark.test.ts
@@ -25,7 +25,7 @@ describeOrSkip('Performance Benchmarks', () => {
         const freshState = createMockState({ includeCodexProvider: true })
         
         const startTime = performance.now()
-        applyProviderFactoryPatch(freshState, mockProvider)
+        applyProviderFactoryPatch(mockProvider)
         const endTime = performance.now()
         
         times.push(endTime - startTime)
@@ -48,7 +48,7 @@ describeOrSkip('Performance Benchmarks', () => {
       
       for (let i = 0; i < 1000; i++) {
         const freshState = createMockState({ includeCodexProvider: true })
-        applyProviderFactoryPatch(freshState, mockProvider)
+        applyProviderFactoryPatch(mockProvider)
       }
       
       const endTime = performance.now()
@@ -68,7 +68,7 @@ describeOrSkip('Performance Benchmarks', () => {
       const baselineMemory = process.memoryUsage()
       
       // Apply patch
-      applyProviderFactoryPatch(mockState, mockProvider)
+      applyProviderFactoryPatch(mockProvider)
       
       // Measure after patch
       const afterPatchMemory = process.memoryUsage()
@@ -90,7 +90,7 @@ describeOrSkip('Performance Benchmarks', () => {
       // Apply many patches
       for (let i = 0; i < 100; i++) {
         const freshState = createMockState({ includeCodexProvider: true })
-        applyProviderFactoryPatch(freshState, mockProvider)
+        applyProviderFactoryPatch(mockProvider)
         
         // Force garbage collection if available
         if (global.gc) {
@@ -117,7 +117,7 @@ describeOrSkip('Performance Benchmarks', () => {
         const freshState = createMockState({ includeCodexProvider: true })
         
         const startTime = performance.now()
-        applyProviderFactoryPatch(freshState, mockProvider)
+        applyProviderFactoryPatch(mockProvider)
         const endTime = performance.now()
         
         times.push(endTime - startTime)
@@ -131,7 +131,7 @@ describeOrSkip('Performance Benchmarks', () => {
     })
 
     it('should handle factory lookup efficiently', async () => {
-      applyProviderFactoryPatch(mockState, mockProvider)
+      applyProviderFactoryPatch(mockProvider)
       
       const iterations = 10000
       const startTime = performance.now()
@@ -152,7 +152,7 @@ describeOrSkip('Performance Benchmarks', () => {
 
   describe('Cache Performance', () => {
     it('should cache factory lookups effectively', async () => {
-      applyProviderFactoryPatch(mockState, mockProvider)
+      applyProviderFactoryPatch(mockProvider)
       
       // First lookup (cache miss)
       const startTime1 = performance.now()

--- a/tests/unit/config-registration.test.ts
+++ b/tests/unit/config-registration.test.ts
@@ -8,6 +8,8 @@ describe("Provider Config Registration", () => {
       project: {} as any,
       directory: "/test",
       worktree: "/test",
+      experimental_workspace: { register: () => {} },
+      serverUrl: new URL("http://localhost:3000"),
       $: {} as any
     })
     
@@ -26,6 +28,8 @@ describe("Provider Config Registration", () => {
       project: {} as any,
       directory: "/test",
       worktree: "/test",
+      experimental_workspace: { register: () => {} },
+      serverUrl: new URL("http://localhost:3000"),
       $: {} as any
     })
 
@@ -43,6 +47,8 @@ describe("Provider Config Registration", () => {
       project: {} as any,
       directory: "/test",
       worktree: "/test",
+      experimental_workspace: { register: () => {} },
+      serverUrl: new URL("http://localhost:3000"),
       $: {} as any
     })
     
@@ -71,6 +77,8 @@ describe("Provider Config Registration", () => {
       project: {} as any,
       directory: "/test",
       worktree: "/test",
+      experimental_workspace: { register: () => {} },
+      serverUrl: new URL("http://localhost:3000"),
       $: {} as any
     })
     

--- a/tests/unit/config-registration.test.ts
+++ b/tests/unit/config-registration.test.ts
@@ -16,8 +16,8 @@ describe("Provider Config Registration", () => {
     
     expect(config.provider.codex).toBeDefined()
     expect(config.provider.codex.name).toBe("Codex CLI")
-    expect(config.provider.codex.models["gpt-5-codex"]).toBeDefined()
-    expect(config.provider.codex.models["gpt-5"]).toBeDefined()
+    expect(config.provider.codex.models["gpt-5.5"]).toBeDefined()
+    expect(config.provider.codex.models["gpt-5.4"]).toBeDefined()
   })
   
   test("sets providerFactory option", async () => {
@@ -62,7 +62,7 @@ describe("Provider Config Registration", () => {
     // Should preserve custom models
     expect(config.provider.codex.models["custom-model"]).toBeDefined()
     // Should still add default models
-    expect(config.provider.codex.models["gpt-5-codex"]).toBeDefined()
+    expect(config.provider.codex.models["gpt-5.5"]).toBeDefined()
   })
   
   test("sets npm package name", async () => {

--- a/tests/unit/config-registration.test.ts
+++ b/tests/unit/config-registration.test.ts
@@ -20,6 +20,7 @@ describe("Provider Config Registration", () => {
     expect(config.provider.codex.name).toBe("Codex CLI")
     expect(config.provider.codex.models["gpt-5.5"]).toBeDefined()
     expect(config.provider.codex.models["gpt-5.4"]).toBeDefined()
+    expect(config.provider.codex.models["gpt-5.2"]).toBeDefined()
   })
   
   test("sets providerFactory option", async () => {
@@ -69,6 +70,8 @@ describe("Provider Config Registration", () => {
     expect(config.provider.codex.models["custom-model"]).toBeDefined()
     // Should still add default models
     expect(config.provider.codex.models["gpt-5.5"]).toBeDefined()
+    expect(config.provider.codex.models["gpt-5.4"]).toBeDefined()
+    expect(config.provider.codex.models["gpt-5.2"]).toBeDefined()
   })
   
   test("sets npm package name", async () => {

--- a/tests/unit/patch-application.test.ts
+++ b/tests/unit/patch-application.test.ts
@@ -113,7 +113,7 @@ describe("Monkey Patch Application", () => {
       // Success is acceptable if Provider module is available
     } catch (error) {
       // Failure is also acceptable if Provider module is not available
-      expect(error.message).toContain("Failed to import Provider module")
+      expect((error as Error).message).toContain("Failed to import Provider module")
     }
   })
 


### PR DESCRIPTION
## Summary

Upgrade the provider from `LanguageModelV2` to `LanguageModelV3`, output v3 format stream events directly, and eliminate the unnecessary v2→v3 intermediate conversion layer.

## Problem

The `opencode run` command outputs completion text correctly, but throws an error every time:

```
Error: undefined is not an object (evaluating '$.inputTokens.total')
```

### Root Cause

opencode's `wrapLanguageModel()` marks all models with `specificationVersion: "v3"` indiscriminately, causing the AI SDK to skip the v2→v3 automatic conversion. However, the plugin outputs v2 format (`inputTokens: 0`, a number), while downstream code expects v3 format (`inputTokens: { total: 0 }`, an object), crashing when accessing `0.total`.

## Changes

| File | Change |
|------|--------|
| `src/codexProvider.ts` | Implement `LanguageModelV3` interface, remove `buildRawStream` and `TransformStream` |
| `src/stream-state.ts` | `finish()` outputs v3 format `finishReason` and `usage` directly |
| `src/utils.ts` | `buildConversationPayload` input type changed to v3 |
| `index.ts` | Add `chat.params` hook to resolve `maxOutputTokens` validation issue |
| `opencode.json` | Update model list to codex MCP actually supported model names |
| `package.json` | `@ai-sdk/provider` upgraded from v2 to v3 |

### Architecture Simplification

```
Before: codex format → StreamState(v2) → TransformStream(v2→v3) → opencode
After:  codex format → StreamState(v3) → opencode
```

## Testing

```bash
opencode run "Hello, world!" --model=codex/gpt-5.5          # ✅ Single turn
opencode run "What is 2+2? Answer with just the number." -m codex/gpt-5.5  # ✅ Single turn
opencode run "First say 'Step 1 done', then say 'Step 2 done'" -m codex/gpt-5.5  # ✅ Multi-step
opencode run "Create a file called /tmp/test.txt with content 'hello', then read it back" -m codex/gpt-5.5  # ✅ Tool call
```

All tests pass without `$.inputTokens.total` errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit GPT-5.5, GPT-5.4, and GPT-5.2 models with defined context/output limits.

* **Chores**
  * Provider migrated to v3 specification.
  * Peer dependency for the provider package tightened to a v3 range.

* **Bug Fixes / Improvements**
  * Improved streaming, usage and finish reporting.
  * Chat output token handling adjusted to better respect limits.

* **Tests**
  * Test suites updated for new defaults and v3-related changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/withakay/opencode-codex-provider/pull/3)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->